### PR TITLE
Add dialog that blocks the screen when connection is lost

### DIFF
--- a/lib/app_localizations.dart
+++ b/lib/app_localizations.dart
@@ -83,6 +83,14 @@ class AppLocalizations {
 
   // Common
 
+  String get okButton {
+    return Intl.message(
+      'OK',
+      name: 'okButton',
+      desc: 'OK button in a dialog',
+    );
+  }
+
   String get continueButton {
     return Intl.message(
       'CONTINUE',
@@ -622,6 +630,24 @@ class AppLocalizations {
       name: 'teamScores',
       args: [thiefScore, agentScore],
       desc: 'The scores of both teams - might need to reverse the order in RTL',
+    );
+  }
+
+  // No connection
+
+  String get noConnectionDialogTitle {
+    return Intl.message(
+      'No internet',
+      name: 'noConnectionDialogTitle',
+      desc: 'Title of the dialog telling the user they have lost their internet connection',
+    );
+  }
+
+  String get noConnectionDialogText {
+    return Intl.message(
+      'You need to be connected to the internet to be able to play.',
+      name: 'noConnectionDialogText',
+      desc: 'Body of the dialog telling the user they have lost their internet connection',
     );
   }
 }

--- a/lib/keys.dart
+++ b/lib/keys.dart
@@ -7,4 +7,6 @@ class Keys {
   static final GlobalKey<FormState> homePageNameKey = new GlobalKey<FormState>();
   static final GlobalKey<FormState> homePageCodeKey = new GlobalKey<FormState>();
   static final GlobalKey<FormState> createRoomPageNameKey = new GlobalKey<FormState>();
+
+  static final GlobalKey noConnectionDialogKey = new GlobalKey();
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2018-09-09T17:11:19.947559",
+  "@@last_modified": "2018-09-15T23:05:02.252363",
   "title": "Heist",
   "@title": {
     "description": "Title for the Heist application",
@@ -33,6 +33,12 @@
   "scaryGhost": "Scary Ghost",
   "@scaryGhost": {
     "description": "Scary Ghost role",
+    "type": "text",
+    "placeholders": {}
+  },
+  "okButton": "OK",
+  "@okButton": {
+    "description": "OK button in a dialog",
     "type": "text",
     "placeholders": {}
   },
@@ -229,15 +235,15 @@
   },
   "brendaReceived": "...received by {brendaDisplayName}",
   "@brendaReceived": {
-    "description": "Describe how much money the Brenda receives after a haunt",
+    "description": "Describe how much money Brenda receives after a haunt",
     "type": "text",
     "placeholders": {
       "brendaDisplayName": {}
     }
   },
-  "sharedBetween": "...shared between the {bertieDisplayName}} and any players who chose {stealOption} on the haunt:",
+  "sharedBetween": "...shared between {bertieDisplayName}} and any players who chose {stealOption} on the haunt:",
   "@sharedBetween": {
-    "description": "Describe how much money gets split between the Bertie and those who stole",
+    "description": "Describe how much money gets split between Bertie and those who stole",
     "type": "text",
     "placeholders": {
       "bertieDisplayName": {},
@@ -467,5 +473,17 @@
       "thiefScore": {},
       "agentScore": {}
     }
+  },
+  "noConnectionDialogTitle": "No internet",
+  "@noConnectionDialogTitle": {
+    "description": "Title of the dialog telling the user they have lost their internet connection",
+    "type": "text",
+    "placeholders": {}
+  },
+  "noConnectionDialogText": "You need to be connected to the internet to be able to play.",
+  "@noConnectionDialogText": {
+    "description": "Body of the dialog telling the user they have lost their internet connection",
+    "type": "text",
+    "placeholders": {}
   }
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -36,6 +36,12 @@
     "type": "text",
     "placeholders": {}
   },
+  "okButton": "OK",
+  "@okButton": {
+    "description": "OK button in a dialog",
+    "type": "text",
+    "placeholders": {}
+  },
   "continueButton": "CONTINUE",
   "@continueButton": {
     "description": "Button for the game organiser to move to the next round or haunt",
@@ -229,15 +235,15 @@
   },
   "brendaReceived": "...received by {brendaDisplayName}",
   "@brendaReceived": {
-    "description": "Describe how much money the Brenda receives after a haunt",
+    "description": "Describe how much money Brenda receives after a haunt",
     "type": "text",
     "placeholders": {
       "brendaDisplayName": {}
     }
   },
-  "sharedBetween": "...shared between the {bertieDisplayName}} and any players who chose {stealOption} on the haunt:",
+  "sharedBetween": "...shared between {bertieDisplayName}} and any players who chose {stealOption} on the haunt:",
   "@sharedBetween": {
-    "description": "Describe how much money gets split between the Bertie and those who stole",
+    "description": "Describe how much money gets split between Bertie and those who stole",
     "type": "text",
     "placeholders": {
       "bertieDisplayName": {},
@@ -467,5 +473,17 @@
       "thiefScore": {},
       "agentScore": {}
     }
+  },
+  "noConnectionDialogTitle": "No internet",
+  "@noConnectionDialogTitle": {
+    "description": "Title of the dialog telling the user they have lost their internet connection",
+    "type": "text",
+    "placeholders": {}
+  },
+  "noConnectionDialogText": "You need to be connected to the internet to be able to play.",
+  "@noConnectionDialogText": {
+    "description": "Body of the dialog telling the user they have lost their internet connection",
+    "type": "text",
+    "placeholders": {}
   }
 }

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2018-09-09T17:11:19.947559",
+  "@@last_modified": "2018-09-15T23:05:02.252363",
   "title": "Heist",
   "@title": {
     "description": "Title for the Heist application",
@@ -33,6 +33,12 @@
   "scaryGhost": "Scary Ghost",
   "@scaryGhost": {
     "description": "Scary Ghost role",
+    "type": "text",
+    "placeholders": {}
+  },
+  "okButton": "OK",
+  "@okButton": {
+    "description": "OK button in a dialog",
     "type": "text",
     "placeholders": {}
   },
@@ -229,15 +235,15 @@
   },
   "brendaReceived": "...received by {brendaDisplayName}",
   "@brendaReceived": {
-    "description": "Describe how much money the Brenda receives after a haunt",
+    "description": "Describe how much money Brenda receives after a haunt",
     "type": "text",
     "placeholders": {
       "brendaDisplayName": {}
     }
   },
-  "sharedBetween": "...shared between the {bertieDisplayName}} and any players who chose {stealOption} on the haunt:",
+  "sharedBetween": "...shared between {bertieDisplayName}} and any players who chose {stealOption} on the haunt:",
   "@sharedBetween": {
-    "description": "Describe how much money gets split between the Bertie and those who stole",
+    "description": "Describe how much money gets split between Bertie and those who stole",
     "type": "text",
     "placeholders": {
       "bertieDisplayName": {},
@@ -467,5 +473,17 @@
       "thiefScore": {},
       "agentScore": {}
     }
+  },
+  "noConnectionDialogTitle": "No internet",
+  "@noConnectionDialogTitle": {
+    "description": "Title of the dialog telling the user they have lost their internet connection",
+    "type": "text",
+    "placeholders": {}
+  },
+  "noConnectionDialogText": "You need to be connected to the internet to be able to play.",
+  "@noConnectionDialogText": {
+    "description": "Body of the dialog telling the user they have lost their internet connection",
+    "type": "text",
+    "placeholders": {}
   }
 }

--- a/lib/l10n/messages_en.dart
+++ b/lib/l10n/messages_en.dart
@@ -49,7 +49,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m15(order) => "Round ${order}";
 
-  static m16(bertieDisplayName, stealOption) => "...shared between the ${bertieDisplayName}} and any players who chose ${stealOption} on the haunt:";
+  static m16(bertieDisplayName, stealOption) => "...shared between ${bertieDisplayName}} and any players who chose ${stealOption} on the haunt:";
 
   static m17(thiefScore, agentScore) => "${thiefScore} - ${agentScore}";
 
@@ -103,7 +103,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "invalidCode" : MessageLookupByLibrary.simpleMessage("Invalid code"),
     "makeYourChoice" : MessageLookupByLibrary.simpleMessage("Make your choice..."),
     "noBid" : MessageLookupByLibrary.simpleMessage("No Bid"),
+    "noConnectionDialogText" : MessageLookupByLibrary.simpleMessage("You need to be connected to the internet to be able to play."),
+    "noConnectionDialogTitle" : MessageLookupByLibrary.simpleMessage("No internet"),
     "notPicked" : MessageLookupByLibrary.simpleMessage("You haven\'t been picked!"),
+    "okButton" : MessageLookupByLibrary.simpleMessage("OK"),
     "otherIdentities" : MessageLookupByLibrary.simpleMessage("You also know these identities:"),
     "pickATeam" : m10,
     "pickedTeamSize" : m11,

--- a/lib/l10n/messages_es.dart
+++ b/lib/l10n/messages_es.dart
@@ -49,7 +49,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m15(order) => "Round ${order}";
 
-  static m16(bertieDisplayName, stealOption) => "...shared between the ${bertieDisplayName}} and any players who chose ${stealOption} on the haunt:";
+  static m16(bertieDisplayName, stealOption) => "...shared between ${bertieDisplayName}} and any players who chose ${stealOption} on the haunt:";
 
   static m17(thiefScore, agentScore) => "${thiefScore} - ${agentScore}";
 
@@ -103,7 +103,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "invalidCode" : MessageLookupByLibrary.simpleMessage("Invalid code"),
     "makeYourChoice" : MessageLookupByLibrary.simpleMessage("Make your choice..."),
     "noBid" : MessageLookupByLibrary.simpleMessage("No Bid"),
+    "noConnectionDialogText" : MessageLookupByLibrary.simpleMessage("You need to be connected to the internet to be able to play."),
+    "noConnectionDialogTitle" : MessageLookupByLibrary.simpleMessage("No internet"),
     "notPicked" : MessageLookupByLibrary.simpleMessage("You haven\'t been picked!"),
+    "okButton" : MessageLookupByLibrary.simpleMessage("OK"),
     "otherIdentities" : MessageLookupByLibrary.simpleMessage("You also know these identities:"),
     "pickATeam" : m10,
     "pickedTeamSize" : m11,

--- a/lib/l10n/messages_messages.dart
+++ b/lib/l10n/messages_messages.dart
@@ -49,7 +49,7 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m15(order) => "Round ${order}";
 
-  static m16(bertieDisplayName, stealOption) => "...shared between the ${bertieDisplayName}} and any players who chose ${stealOption} on the haunt:";
+  static m16(bertieDisplayName, stealOption) => "...shared between ${bertieDisplayName}} and any players who chose ${stealOption} on the haunt:";
 
   static m17(thiefScore, agentScore) => "${thiefScore} - ${agentScore}";
 
@@ -103,7 +103,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "invalidCode" : MessageLookupByLibrary.simpleMessage("Invalid code"),
     "makeYourChoice" : MessageLookupByLibrary.simpleMessage("Make your choice..."),
     "noBid" : MessageLookupByLibrary.simpleMessage("No Bid"),
+    "noConnectionDialogText" : MessageLookupByLibrary.simpleMessage("You need to be connected to the internet to be able to play."),
+    "noConnectionDialogTitle" : MessageLookupByLibrary.simpleMessage("No internet"),
     "notPicked" : MessageLookupByLibrary.simpleMessage("You haven\'t been picked!"),
+    "okButton" : MessageLookupByLibrary.simpleMessage("OK"),
     "otherIdentities" : MessageLookupByLibrary.simpleMessage("You also know these identities:"),
     "pickATeam" : m10,
     "pickedTeamSize" : m11,

--- a/lib/widget/common.dart
+++ b/lib/widget/common.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:heist/app_localizations.dart';
 import 'package:heist/colors.dart';
 import 'package:heist/db/database_model.dart';
+import 'package:heist/keys.dart';
 import 'package:heist/selectors/selectors.dart';
 import 'package:heist/state.dart';
 import 'package:redux/redux.dart';
@@ -157,4 +160,39 @@ Widget iconText(Icon icon, Text text, {bool trailingIcon = false}) {
     crossAxisAlignment: CrossAxisAlignment.center,
     children: children,
   );
+}
+
+Future<Null> showNoConnectionDialog(BuildContext context) async {
+  return showDialog<Null>(
+    context: context,
+    barrierDismissible: false, // not dismissable
+    builder: (BuildContext context) {
+      return WillPopScope(
+        onWillPop: () {
+          // intercept back button and go to home page when tapped
+          return new Future(() async {
+            _goBackToMainPage(context);
+            return false;
+          });
+        },
+        child: new AlertDialog(
+          key: Keys.noConnectionDialogKey,
+          title: new Text(AppLocalizations.of(context).noConnectionDialogTitle),
+          content: new Text(AppLocalizations.of(context).noConnectionDialogText),
+          actions: <Widget>[
+            new FlatButton(
+              child: new Text(AppLocalizations.of(context).okButton),
+              onPressed: () {
+                _goBackToMainPage(context);
+              },
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+_goBackToMainPage(BuildContext context) {
+  Navigator.popUntil(context, ModalRoute.withName('/'));
 }

--- a/lib/widget/create_room_page.dart
+++ b/lib/widget/create_room_page.dart
@@ -62,15 +62,11 @@ class CreateRoomPage extends StatelessWidget {
   Widget _createRoomButton(BuildContext context, Store<GameModel> store) => new RaisedButton(
         child: new Text(AppLocalizations.of(context).createRoom, style: buttonTextStyle),
         onPressed: () async {
-          var connectivityResult = await (new Connectivity().checkConnectivity());
-          if (connectivityResult != ConnectivityResult.none) {
-            FormState enterNameState = Keys.createRoomPageNameKey.currentState;
-            if (enterNameState.validate()) {
-              enterNameState.save();
-              store.dispatch(new CreateRoomAction());
-            }
-          } else {
-            showNoConnectionDialog(context);
+          FormState enterNameState = Keys.createRoomPageNameKey.currentState;
+          if (enterNameState.validate()) {
+            enterNameState.save();
+            store.dispatch(new CreateRoomAction(
+                context, () => new Connectivity().checkConnectivity()));
           }
         },
       );

--- a/lib/widget/create_room_page.dart
+++ b/lib/widget/create_room_page.dart
@@ -1,3 +1,4 @@
+import 'package:connectivity/connectivity.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_redux_dev_tools/flutter_redux_dev_tools.dart';
@@ -60,11 +61,16 @@ class CreateRoomPage extends StatelessWidget {
 
   Widget _createRoomButton(BuildContext context, Store<GameModel> store) => new RaisedButton(
         child: new Text(AppLocalizations.of(context).createRoom, style: buttonTextStyle),
-        onPressed: () {
-          FormState enterNameState = Keys.createRoomPageNameKey.currentState;
-          if (enterNameState.validate()) {
-            enterNameState.save();
-            store.dispatch(new CreateRoomAction());
+        onPressed: () async {
+          var connectivityResult = await (new Connectivity().checkConnectivity());
+          if (connectivityResult != ConnectivityResult.none) {
+            FormState enterNameState = Keys.createRoomPageNameKey.currentState;
+            if (enterNameState.validate()) {
+              enterNameState.save();
+              store.dispatch(new CreateRoomAction());
+            }
+          } else {
+            showNoConnectionDialog(context);
           }
         },
       );

--- a/lib/widget/game.dart
+++ b/lib/widget/game.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
+import 'package:connectivity/connectivity.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_redux_dev_tools/flutter_redux_dev_tools.dart';
 import 'package:heist/app_localizations.dart';
 import 'package:heist/db/database_model.dart';
+import 'package:heist/keys.dart';
 import 'package:heist/main.dart';
 import 'package:heist/middleware/game_middleware.dart';
 import 'package:heist/middleware/room_middleware.dart';
@@ -38,6 +42,8 @@ class Game extends StatefulWidget {
 
 class GameState extends State<Game> {
   final Store<GameModel> _store;
+  StreamSubscription _subscription;
+  Timer _timer;
 
   GameState(this._store);
 
@@ -45,10 +51,32 @@ class GameState extends State<Game> {
   void initState() {
     super.initState();
     _store.dispatch(new LoadGameAction());
+    _subscription = new Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
+      // Note that on Android, this does not guarantee connection to Internet.
+      // For instance, the app might have wifi access but it might be a VPN or
+      // a hotel WiFi with no access.
+      debugPrint('Status changed: ' + result.toString());
+      if (result == ConnectivityResult.none) {
+        // connectivity was lost, start the timer
+        _timer = new Timer(const Duration(seconds: 5), () => showNoConnectionDialog(context));
+      } else {
+        // connectivity is back, cancel the timer
+        _timer.cancel();
+        // and dismiss the dialog if it's shown
+        if (Keys.noConnectionDialogKey.currentWidget != null) {
+          Navigator.pop(context);
+        }
+
+      }
+    });
   }
+
+
+
 
   @override
   void dispose() {
+    _subscription.cancel();
     resetGameStore(_store);
     super.dispose();
   }

--- a/lib/widget/game.dart
+++ b/lib/widget/game.dart
@@ -42,8 +42,8 @@ class Game extends StatefulWidget {
 
 class GameState extends State<Game> {
   final Store<GameModel> _store;
-  StreamSubscription _subscription;
-  Timer _timer;
+  StreamSubscription _connectivitySubscription;
+  Timer _connectivityTimer;
 
   GameState(this._store);
 
@@ -51,17 +51,17 @@ class GameState extends State<Game> {
   void initState() {
     super.initState();
     _store.dispatch(new LoadGameAction());
-    _subscription = new Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
+    _connectivitySubscription = new Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
       // Note that on Android, this does not guarantee connection to Internet.
       // For instance, the app might have wifi access but it might be a VPN or
       // a hotel WiFi with no access.
       debugPrint('Status changed: ' + result.toString());
       if (result == ConnectivityResult.none) {
         // connectivity was lost, start the timer
-        _timer = new Timer(const Duration(seconds: 5), () => showNoConnectionDialog(context));
+        _connectivityTimer = new Timer(const Duration(seconds: 5), () => showNoConnectionDialog(context));
       } else {
         // connectivity is back, cancel the timer
-        _timer.cancel();
+        _connectivityTimer.cancel();
         // and dismiss the dialog if it's shown
         if (Keys.noConnectionDialogKey.currentWidget != null) {
           Navigator.pop(context);
@@ -76,7 +76,7 @@ class GameState extends State<Game> {
 
   @override
   void dispose() {
-    _subscription.cancel();
+    _connectivitySubscription.cancel();
     resetGameStore(_store);
     super.dispose();
   }

--- a/lib/widget/home_page.dart
+++ b/lib/widget/home_page.dart
@@ -13,7 +13,6 @@ import 'package:heist/selectors/selectors.dart';
 import 'package:heist/state.dart';
 import 'package:heist/widget/create_room_page.dart';
 import 'package:redux/redux.dart';
-import 'dart:async';
 
 import 'common.dart';
 
@@ -43,17 +42,13 @@ class HomePage extends StatelessWidget {
   Widget _enterRoomButton(BuildContext context, Store<GameModel> store) => new RaisedButton(
         child: Text(AppLocalizations.of(context).enterRoom, style: buttonTextStyle),
         onPressed: () async {
-          var connectivityResult = await (new Connectivity().checkConnectivity());
-          if (connectivityResult != ConnectivityResult.none) {
-            FormState enterCodeState = Keys.homePageCodeKey.currentState;
-            FormState enterNameState = Keys.homePageNameKey.currentState;
-            if (enterCodeState.validate()) {
-              enterCodeState.save();
-              enterNameState.save();
-              store.dispatch(new ValidateRoomAction(context));
-            }
-          } else {
-            showNoConnectionDialog(context);
+          FormState enterCodeState = Keys.homePageCodeKey.currentState;
+          FormState enterNameState = Keys.homePageNameKey.currentState;
+          if (enterCodeState.validate()) {
+            enterCodeState.save();
+            enterNameState.save();
+            store.dispatch(new ValidateRoomAction(
+                context, () => new Connectivity().checkConnectivity()));
           }
         },
       );

--- a/lib/widget/home_page.dart
+++ b/lib/widget/home_page.dart
@@ -1,3 +1,4 @@
+import 'package:connectivity/connectivity.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_redux/flutter_redux.dart';
@@ -12,6 +13,7 @@ import 'package:heist/selectors/selectors.dart';
 import 'package:heist/state.dart';
 import 'package:heist/widget/create_room_page.dart';
 import 'package:redux/redux.dart';
+import 'dart:async';
 
 import 'common.dart';
 
@@ -40,13 +42,18 @@ class HomePage extends StatelessWidget {
 
   Widget _enterRoomButton(BuildContext context, Store<GameModel> store) => new RaisedButton(
         child: Text(AppLocalizations.of(context).enterRoom, style: buttonTextStyle),
-        onPressed: () {
-          FormState enterCodeState = Keys.homePageCodeKey.currentState;
-          FormState enterNameState = Keys.homePageNameKey.currentState;
-          if (enterCodeState.validate()) {
-            enterCodeState.save();
-            enterNameState.save();
-            store.dispatch(new ValidateRoomAction(context));
+        onPressed: () async {
+          var connectivityResult = await (new Connectivity().checkConnectivity());
+          if (connectivityResult != ConnectivityResult.none) {
+            FormState enterCodeState = Keys.homePageCodeKey.currentState;
+            FormState enterNameState = Keys.homePageNameKey.currentState;
+            if (enterCodeState.validate()) {
+              enterCodeState.save();
+              enterNameState.save();
+              store.dispatch(new ValidateRoomAction(context));
+            }
+          } else {
+            showNoConnectionDialog(context);
           }
         },
       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,6 +50,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.14.11"
+  connectivity:
+    dependency: "direct main"
+    description:
+      name: connectivity
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.1"
   convert:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter_redux_dev_tools: ^0.3.0
   flutter_localizations:
       sdk: flutter
+  connectivity: ^0.3.1
 
 dev_dependencies:
   flutter_test:

--- a/test/middleware/room_middleware_test.dart
+++ b/test/middleware/room_middleware_test.dart
@@ -19,7 +19,7 @@ void main() {
     Store<GameModel> store = createStore(db, minPlayers);
     store.dispatch(new SavePlayerNameAction('_name'));
 
-    await handle(store, new CreateRoomAction());
+    await handle(store, new CreateRoomAction(null, () => true));
     expect(store.state.room.code.length, 4);
     expect(store.state.room.appVersion, isNotNull);
     expect(store.state.room.numPlayers, minPlayers);

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -32,7 +32,7 @@ Future<Store<GameModel>> initGame() async {
   FirestoreDb db = new MockFirestoreDb.empty();
   Store<GameModel> store = createStore(db, minPlayers);
   store.dispatch(new SavePlayerNameAction('_name'));
-  await handle(store, new CreateRoomAction());
+  await handle(store, new CreateRoomAction(null, () => true));
   await new LoadGameAction().loadGame(store);
   await handle(store, new JoinGameAction());
   await addOtherPlayers(store);


### PR DESCRIPTION
No internet behaviour.

There is a unique dialog for all the cases where we say there's no internet. It appears when the user presses the "create room" or "enter room" without internet or when connectivity is lost for more than 5 seconds during the game. If you press the "OK" button or the back button, you go back to the home page.  During the game, if the dialog appears and you recover connectivity while it's on screen, it disappears.