### PR TITLE
Current round fixes

### DIFF
--- a/lib/app_localizations.dart
+++ b/lib/app_localizations.dart
@@ -325,7 +325,7 @@ class AppLocalizations {
 
   String get goingAhead {
     return Intl.message(
-      'The haunt is going ahead!',
+      'The haunt is going ahead without you!',
       name: 'goingAhead',
       desc: 'Bidding phase result',
     );

--- a/lib/app_localizations.dart
+++ b/lib/app_localizations.dart
@@ -376,7 +376,7 @@ class AppLocalizations {
 
   String sharedBetween(String bertieDisplayName, String stealOption) {
     return Intl.message(
-      '...shared between $bertieDisplayName} and any players who chose $stealOption on the haunt:',
+      '...shared between $bertieDisplayName and any players who chose $stealOption on the haunt:',
       name: 'sharedBetween',
       args: [bertieDisplayName, stealOption],
       desc: 'Describe how much money gets split between Bertie and those who stole',
@@ -639,15 +639,6 @@ class AppLocalizations {
       name: 'hauntPrice',
       args: [price],
       desc: 'Price of a haunt',
-    );
-  }
-
-  String hauntPot(int pot) {
-    return Intl.message(
-      'Pot: $pot',
-      name: 'hauntPot',
-      args: [pot],
-      desc: 'Pot of a haunt',
     );
   }
 

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2018-09-21T19:01:46.816900",
+  "@@last_modified": "2018-09-28T00:33:47.741137",
   "title": "Heist",
   "@title": {
     "description": "Title for the Heist application",
@@ -218,7 +218,7 @@
     "type": "text",
     "placeholders": {}
   },
-  "goingAhead": "The haunt is going ahead!",
+  "goingAhead": "The haunt is going ahead without you!",
   "@goingAhead": {
     "description": "Bidding phase result",
     "type": "text",
@@ -256,7 +256,7 @@
       "brendaDisplayName": {}
     }
   },
-  "sharedBetween": "...shared between {bertieDisplayName}} and any players who chose {stealOption} on the haunt:",
+  "sharedBetween": "...shared between {bertieDisplayName} and any players who chose {stealOption} on the haunt:",
   "@sharedBetween": {
     "description": "Describe how much money gets split between Bertie and those who stole",
     "type": "text",
@@ -470,14 +470,6 @@
     "type": "text",
     "placeholders": {
       "price": {}
-    }
-  },
-  "hauntPot": "Pot: {pot}",
-  "@hauntPot": {
-    "description": "Pot of a haunt",
-    "type": "text",
-    "placeholders": {
-      "pot": {}
     }
   },
   "winner": "{winner} win!",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2018-09-21T19:01:46.816900",
+  "@@last_modified": "2018-09-28T00:33:47.741137",
   "title": "Heist",
   "@title": {
     "description": "Title for the Heist application",
@@ -218,7 +218,7 @@
     "type": "text",
     "placeholders": {}
   },
-  "goingAhead": "The haunt is going ahead!",
+  "goingAhead": "The haunt is going ahead without you!",
   "@goingAhead": {
     "description": "Bidding phase result",
     "type": "text",
@@ -256,7 +256,7 @@
       "brendaDisplayName": {}
     }
   },
-  "sharedBetween": "...shared between {bertieDisplayName}} and any players who chose {stealOption} on the haunt:",
+  "sharedBetween": "...shared between {bertieDisplayName} and any players who chose {stealOption} on the haunt:",
   "@sharedBetween": {
     "description": "Describe how much money gets split between Bertie and those who stole",
     "type": "text",
@@ -470,14 +470,6 @@
     "type": "text",
     "placeholders": {
       "price": {}
-    }
-  },
-  "hauntPot": "Pot: {pot}",
-  "@hauntPot": {
-    "description": "Pot of a haunt",
-    "type": "text",
-    "placeholders": {
-      "pot": {}
     }
   },
   "winner": "{winner} win!",

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2018-09-21T19:01:46.816900",
+  "@@last_modified": "2018-09-28T00:33:47.741137",
   "title": "Heist",
   "@title": {
     "description": "Title for the Heist application",
@@ -218,7 +218,7 @@
     "type": "text",
     "placeholders": {}
   },
-  "goingAhead": "The haunt is going ahead!",
+  "goingAhead": "The haunt is going ahead without you!",
   "@goingAhead": {
     "description": "Bidding phase result",
     "type": "text",
@@ -256,7 +256,7 @@
       "brendaDisplayName": {}
     }
   },
-  "sharedBetween": "...shared between {bertieDisplayName}} and any players who chose {stealOption} on the haunt:",
+  "sharedBetween": "...shared between {bertieDisplayName} and any players who chose {stealOption} on the haunt:",
   "@sharedBetween": {
     "description": "Describe how much money gets split between Bertie and those who stole",
     "type": "text",
@@ -470,14 +470,6 @@
     "type": "text",
     "placeholders": {
       "price": {}
-    }
-  },
-  "hauntPot": "Pot: {pot}",
-  "@hauntPot": {
-    "description": "Pot of a haunt",
-    "type": "text",
-    "placeholders": {
-      "pot": {}
     }
   },
   "winner": "{winner} win!",

--- a/lib/l10n/messages_en.dart
+++ b/lib/l10n/messages_en.dart
@@ -29,33 +29,31 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m5(amount, recipientName) => "You have already sent a gift this round of ${amount} to ${recipientName}";
 
-  static m6(pot) => "Pot: ${pot}";
+  static m6(price) => "Price: ${price}";
 
-  static m7(price) => "Price: ${price}";
+  static m7(order) => "Haunt ${order}";
 
-  static m8(order) => "Haunt ${order}";
+  static m8(name, role) => "${name} is the ${role} \n";
 
-  static m9(name, role) => "${name} is the ${role} \n";
+  static m9(playersPicked, teamSize) => "Pick a team: ${playersPicked} / ${teamSize}";
 
-  static m10(playersPicked, teamSize) => "Pick a team: ${playersPicked} / ${teamSize}";
+  static m10(playersPicked, teamSize) => "TEAM (${playersPicked} / ${teamSize})";
 
-  static m11(playersPicked, teamSize) => "TEAM (${playersPicked} / ${teamSize})";
+  static m11(order) => "Player ${order}";
 
-  static m12(order) => "Player ${order}";
+  static m12(name, role) => "${name} (${role}) ->";
 
-  static m13(name, role) => "${name} (${role}) ->";
+  static m13(order) => "Round ${order}";
 
-  static m14(order) => "Round ${order}";
+  static m14(bertieDisplayName, stealOption) => "...shared between ${bertieDisplayName} and any players who chose ${stealOption} on the haunt:";
 
-  static m15(bertieDisplayName, stealOption) => "...shared between ${bertieDisplayName}} and any players who chose ${stealOption} on the haunt:";
+  static m15(thiefScore, agentScore) => "${thiefScore} - ${agentScore}";
 
-  static m16(thiefScore, agentScore) => "${thiefScore} - ${agentScore}";
+  static m16(playersSoFar, totalPlayers) => "Waiting for players: ${playersSoFar} / ${totalPlayers}";
 
-  static m17(playersSoFar, totalPlayers) => "Waiting for players: ${playersSoFar} / ${totalPlayers}";
+  static m17(leaderName) => "Waiting for ${leaderName} to submit team";
 
-  static m18(leaderName) => "Waiting for ${leaderName} to submit team";
-
-  static m19(winner) => "${winner} win!";
+  static m18(winner) => "${winner} win!";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => <String, Function> {
@@ -91,13 +89,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "gameTab" : MessageLookupByLibrary.simpleMessage("GAME"),
     "giftAlreadySent" : m5,
     "giftingTitle" : MessageLookupByLibrary.simpleMessage("GIFTING"),
-    "goingAhead" : MessageLookupByLibrary.simpleMessage("The haunt is going ahead!"),
+    "goingAhead" : MessageLookupByLibrary.simpleMessage("The haunt is going ahead without you!"),
     "hauntInProgress" : MessageLookupByLibrary.simpleMessage("Haunt in progress..."),
-    "hauntPot" : m6,
-    "hauntPrice" : m7,
-    "hauntTitle" : m8,
+    "hauntPrice" : m6,
+    "hauntTitle" : m7,
     "homepageTitle" : MessageLookupByLibrary.simpleMessage("Homepage"),
-    "identity" : m9,
+    "identity" : m8,
     "invalidCode" : MessageLookupByLibrary.simpleMessage("Invalid code"),
     "joinGame" : MessageLookupByLibrary.simpleMessage("JOIN GAME"),
     "makeYourChoice" : MessageLookupByLibrary.simpleMessage("Make your choice..."),
@@ -108,29 +105,29 @@ class MessageLookup extends MessageLookupByLibrary {
     "notPicked" : MessageLookupByLibrary.simpleMessage("You haven\'t been picked!"),
     "okButton" : MessageLookupByLibrary.simpleMessage("OK"),
     "otherIdentities" : MessageLookupByLibrary.simpleMessage("You also know these identities:"),
-    "pickATeam" : m10,
-    "pickedTeamSize" : m11,
+    "pickATeam" : m9,
+    "pickedTeamSize" : m10,
     "pickedYou" : MessageLookupByLibrary.simpleMessage(" picked you in the team!"),
-    "playerOrder" : m12,
-    "playerRole" : m13,
+    "playerOrder" : m11,
+    "playerRole" : m12,
     "players" : MessageLookupByLibrary.simpleMessage("Players"),
     "pleaseEnterAName" : MessageLookupByLibrary.simpleMessage("Please enter a name"),
     "pot" : MessageLookupByLibrary.simpleMessage("Pot"),
     "price" : MessageLookupByLibrary.simpleMessage("Price"),
     "putYouInTeam" : MessageLookupByLibrary.simpleMessage(" to put you in the team!"),
-    "roundTitle" : m14,
+    "roundTitle" : m13,
     "scaryGhost" : MessageLookupByLibrary.simpleMessage("Scary Ghost"),
     "secretTab" : MessageLookupByLibrary.simpleMessage("SECRET"),
-    "sharedBetween" : m15,
+    "sharedBetween" : m14,
     "submitBid" : MessageLookupByLibrary.simpleMessage("SUBMIT BID"),
     "submitTeam" : MessageLookupByLibrary.simpleMessage("SUBMIT TEAM"),
     "success" : MessageLookupByLibrary.simpleMessage("Success"),
-    "teamScores" : m16,
+    "teamScores" : m15,
     "title" : MessageLookupByLibrary.simpleMessage("Heist"),
     "unlimited" : MessageLookupByLibrary.simpleMessage("You have no maximum bid limit for this round"),
-    "waitingForPlayers" : m17,
-    "waitingForTeamSubmission" : m18,
-    "winner" : m19,
+    "waitingForPlayers" : m16,
+    "waitingForTeamSubmission" : m17,
+    "winner" : m18,
     "youAreGoing" : MessageLookupByLibrary.simpleMessage("You\'re going on a haunt!"),
     "youHaveMadeYourChoice" : MessageLookupByLibrary.simpleMessage("You have made your choice!"),
     "yourBid" : MessageLookupByLibrary.simpleMessage("Your bid"),

--- a/lib/l10n/messages_es.dart
+++ b/lib/l10n/messages_es.dart
@@ -29,33 +29,31 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m5(amount, recipientName) => "You have already sent a gift this round of ${amount} to ${recipientName}";
 
-  static m6(pot) => "Pot: ${pot}";
+  static m6(price) => "Price: ${price}";
 
-  static m7(price) => "Price: ${price}";
+  static m7(order) => "Haunt ${order}";
 
-  static m8(order) => "Haunt ${order}";
+  static m8(name, role) => "${name} is the ${role} \n";
 
-  static m9(name, role) => "${name} is the ${role} \n";
+  static m9(playersPicked, teamSize) => "Pick a team: ${playersPicked} / ${teamSize}";
 
-  static m10(playersPicked, teamSize) => "Pick a team: ${playersPicked} / ${teamSize}";
+  static m10(playersPicked, teamSize) => "TEAM (${playersPicked} / ${teamSize})";
 
-  static m11(playersPicked, teamSize) => "TEAM (${playersPicked} / ${teamSize})";
+  static m11(order) => "Player ${order}";
 
-  static m12(order) => "Player ${order}";
+  static m12(name, role) => "${name} (${role}) ->";
 
-  static m13(name, role) => "${name} (${role}) ->";
+  static m13(order) => "Round ${order}";
 
-  static m14(order) => "Round ${order}";
+  static m14(bertieDisplayName, stealOption) => "...shared between ${bertieDisplayName} and any players who chose ${stealOption} on the haunt:";
 
-  static m15(bertieDisplayName, stealOption) => "...shared between ${bertieDisplayName}} and any players who chose ${stealOption} on the haunt:";
+  static m15(thiefScore, agentScore) => "${thiefScore} - ${agentScore}";
 
-  static m16(thiefScore, agentScore) => "${thiefScore} - ${agentScore}";
+  static m16(playersSoFar, totalPlayers) => "Waiting for players: ${playersSoFar} / ${totalPlayers}";
 
-  static m17(playersSoFar, totalPlayers) => "Waiting for players: ${playersSoFar} / ${totalPlayers}";
+  static m17(leaderName) => "Waiting for ${leaderName} to submit team";
 
-  static m18(leaderName) => "Waiting for ${leaderName} to submit team";
-
-  static m19(winner) => "${winner} win!";
+  static m18(winner) => "${winner} win!";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => <String, Function> {
@@ -91,13 +89,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "gameTab" : MessageLookupByLibrary.simpleMessage("GAME"),
     "giftAlreadySent" : m5,
     "giftingTitle" : MessageLookupByLibrary.simpleMessage("GIFTING"),
-    "goingAhead" : MessageLookupByLibrary.simpleMessage("The haunt is going ahead!"),
+    "goingAhead" : MessageLookupByLibrary.simpleMessage("The haunt is going ahead without you!"),
     "hauntInProgress" : MessageLookupByLibrary.simpleMessage("Haunt in progress..."),
-    "hauntPot" : m6,
-    "hauntPrice" : m7,
-    "hauntTitle" : m8,
+    "hauntPrice" : m6,
+    "hauntTitle" : m7,
     "homepageTitle" : MessageLookupByLibrary.simpleMessage("Homepage"),
-    "identity" : m9,
+    "identity" : m8,
     "invalidCode" : MessageLookupByLibrary.simpleMessage("Invalid code"),
     "joinGame" : MessageLookupByLibrary.simpleMessage("JOIN GAME"),
     "makeYourChoice" : MessageLookupByLibrary.simpleMessage("Make your choice..."),
@@ -108,29 +105,29 @@ class MessageLookup extends MessageLookupByLibrary {
     "notPicked" : MessageLookupByLibrary.simpleMessage("You haven\'t been picked!"),
     "okButton" : MessageLookupByLibrary.simpleMessage("OK"),
     "otherIdentities" : MessageLookupByLibrary.simpleMessage("You also know these identities:"),
-    "pickATeam" : m10,
-    "pickedTeamSize" : m11,
+    "pickATeam" : m9,
+    "pickedTeamSize" : m10,
     "pickedYou" : MessageLookupByLibrary.simpleMessage(" picked you in the team!"),
-    "playerOrder" : m12,
-    "playerRole" : m13,
+    "playerOrder" : m11,
+    "playerRole" : m12,
     "players" : MessageLookupByLibrary.simpleMessage("Players"),
     "pleaseEnterAName" : MessageLookupByLibrary.simpleMessage("Please enter a name"),
     "pot" : MessageLookupByLibrary.simpleMessage("Pot"),
     "price" : MessageLookupByLibrary.simpleMessage("Price"),
     "putYouInTeam" : MessageLookupByLibrary.simpleMessage(" to put you in the team!"),
-    "roundTitle" : m14,
+    "roundTitle" : m13,
     "scaryGhost" : MessageLookupByLibrary.simpleMessage("Scary Ghost"),
     "secretTab" : MessageLookupByLibrary.simpleMessage("SECRET"),
-    "sharedBetween" : m15,
+    "sharedBetween" : m14,
     "submitBid" : MessageLookupByLibrary.simpleMessage("SUBMIT BID"),
     "submitTeam" : MessageLookupByLibrary.simpleMessage("SUBMIT TEAM"),
     "success" : MessageLookupByLibrary.simpleMessage("Success"),
-    "teamScores" : m16,
+    "teamScores" : m15,
     "title" : MessageLookupByLibrary.simpleMessage("Heist"),
     "unlimited" : MessageLookupByLibrary.simpleMessage("You have no maximum bid limit for this round"),
-    "waitingForPlayers" : m17,
-    "waitingForTeamSubmission" : m18,
-    "winner" : m19,
+    "waitingForPlayers" : m16,
+    "waitingForTeamSubmission" : m17,
+    "winner" : m18,
     "youAreGoing" : MessageLookupByLibrary.simpleMessage("You\'re going on a haunt!"),
     "youHaveMadeYourChoice" : MessageLookupByLibrary.simpleMessage("You have made your choice!"),
     "yourBid" : MessageLookupByLibrary.simpleMessage("Your bid"),

--- a/lib/l10n/messages_messages.dart
+++ b/lib/l10n/messages_messages.dart
@@ -29,33 +29,31 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static m5(amount, recipientName) => "You have already sent a gift this round of ${amount} to ${recipientName}";
 
-  static m6(pot) => "Pot: ${pot}";
+  static m6(price) => "Price: ${price}";
 
-  static m7(price) => "Price: ${price}";
+  static m7(order) => "Haunt ${order}";
 
-  static m8(order) => "Haunt ${order}";
+  static m8(name, role) => "${name} is the ${role} \n";
 
-  static m9(name, role) => "${name} is the ${role} \n";
+  static m9(playersPicked, teamSize) => "Pick a team: ${playersPicked} / ${teamSize}";
 
-  static m10(playersPicked, teamSize) => "Pick a team: ${playersPicked} / ${teamSize}";
+  static m10(playersPicked, teamSize) => "TEAM (${playersPicked} / ${teamSize})";
 
-  static m11(playersPicked, teamSize) => "TEAM (${playersPicked} / ${teamSize})";
+  static m11(order) => "Player ${order}";
 
-  static m12(order) => "Player ${order}";
+  static m12(name, role) => "${name} (${role}) ->";
 
-  static m13(name, role) => "${name} (${role}) ->";
+  static m13(order) => "Round ${order}";
 
-  static m14(order) => "Round ${order}";
+  static m14(bertieDisplayName, stealOption) => "...shared between ${bertieDisplayName} and any players who chose ${stealOption} on the haunt:";
 
-  static m15(bertieDisplayName, stealOption) => "...shared between ${bertieDisplayName}} and any players who chose ${stealOption} on the haunt:";
+  static m15(thiefScore, agentScore) => "${thiefScore} - ${agentScore}";
 
-  static m16(thiefScore, agentScore) => "${thiefScore} - ${agentScore}";
+  static m16(playersSoFar, totalPlayers) => "Waiting for players: ${playersSoFar} / ${totalPlayers}";
 
-  static m17(playersSoFar, totalPlayers) => "Waiting for players: ${playersSoFar} / ${totalPlayers}";
+  static m17(leaderName) => "Waiting for ${leaderName} to submit team";
 
-  static m18(leaderName) => "Waiting for ${leaderName} to submit team";
-
-  static m19(winner) => "${winner} win!";
+  static m18(winner) => "${winner} win!";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static _notInlinedMessages(_) => <String, Function> {
@@ -91,13 +89,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "gameTab" : MessageLookupByLibrary.simpleMessage("GAME"),
     "giftAlreadySent" : m5,
     "giftingTitle" : MessageLookupByLibrary.simpleMessage("GIFTING"),
-    "goingAhead" : MessageLookupByLibrary.simpleMessage("The haunt is going ahead!"),
+    "goingAhead" : MessageLookupByLibrary.simpleMessage("The haunt is going ahead without you!"),
     "hauntInProgress" : MessageLookupByLibrary.simpleMessage("Haunt in progress..."),
-    "hauntPot" : m6,
-    "hauntPrice" : m7,
-    "hauntTitle" : m8,
+    "hauntPrice" : m6,
+    "hauntTitle" : m7,
     "homepageTitle" : MessageLookupByLibrary.simpleMessage("Homepage"),
-    "identity" : m9,
+    "identity" : m8,
     "invalidCode" : MessageLookupByLibrary.simpleMessage("Invalid code"),
     "joinGame" : MessageLookupByLibrary.simpleMessage("JOIN GAME"),
     "makeYourChoice" : MessageLookupByLibrary.simpleMessage("Make your choice..."),
@@ -108,29 +105,29 @@ class MessageLookup extends MessageLookupByLibrary {
     "notPicked" : MessageLookupByLibrary.simpleMessage("You haven\'t been picked!"),
     "okButton" : MessageLookupByLibrary.simpleMessage("OK"),
     "otherIdentities" : MessageLookupByLibrary.simpleMessage("You also know these identities:"),
-    "pickATeam" : m10,
-    "pickedTeamSize" : m11,
+    "pickATeam" : m9,
+    "pickedTeamSize" : m10,
     "pickedYou" : MessageLookupByLibrary.simpleMessage(" picked you in the team!"),
-    "playerOrder" : m12,
-    "playerRole" : m13,
+    "playerOrder" : m11,
+    "playerRole" : m12,
     "players" : MessageLookupByLibrary.simpleMessage("Players"),
     "pleaseEnterAName" : MessageLookupByLibrary.simpleMessage("Please enter a name"),
     "pot" : MessageLookupByLibrary.simpleMessage("Pot"),
     "price" : MessageLookupByLibrary.simpleMessage("Price"),
     "putYouInTeam" : MessageLookupByLibrary.simpleMessage(" to put you in the team!"),
-    "roundTitle" : m14,
+    "roundTitle" : m13,
     "scaryGhost" : MessageLookupByLibrary.simpleMessage("Scary Ghost"),
     "secretTab" : MessageLookupByLibrary.simpleMessage("SECRET"),
-    "sharedBetween" : m15,
+    "sharedBetween" : m14,
     "submitBid" : MessageLookupByLibrary.simpleMessage("SUBMIT BID"),
     "submitTeam" : MessageLookupByLibrary.simpleMessage("SUBMIT TEAM"),
     "success" : MessageLookupByLibrary.simpleMessage("Success"),
-    "teamScores" : m16,
+    "teamScores" : m15,
     "title" : MessageLookupByLibrary.simpleMessage("Heist"),
     "unlimited" : MessageLookupByLibrary.simpleMessage("You have no maximum bid limit for this round"),
-    "waitingForPlayers" : m17,
-    "waitingForTeamSubmission" : m18,
-    "winner" : m19,
+    "waitingForPlayers" : m16,
+    "waitingForTeamSubmission" : m17,
+    "winner" : m18,
     "youAreGoing" : MessageLookupByLibrary.simpleMessage("You\'re going on a haunt!"),
     "youHaveMadeYourChoice" : MessageLookupByLibrary.simpleMessage("You have made your choice!"),
     "yourBid" : MessageLookupByLibrary.simpleMessage("Your bid"),

--- a/lib/selectors/haunt_selectors.dart
+++ b/lib/selectors/haunt_selectors.dart
@@ -5,18 +5,25 @@ import 'package:reselect/reselect.dart';
 
 import 'selectors.dart';
 
-final Selector<GameModel, bool> hauntIsActive = createSelector4(
-    getRounds, currentHaunt, biddingComplete, isAuction,
-    (Map<String, List<Round>> rounds, Haunt currentHaunt, bool biddingComplete, bool isAuction) {
-  bool priceMet = rounds[currentHaunt.id]
-      .any((r) => r.pot >= currentHaunt.price && r.teamSubmitted && r.complete);
-  return ((isAuction && biddingComplete) || priceMet) &&
-      !currentHaunt.complete &&
-      !currentHaunt.allDecided;
-});
+bool hauntHasActiveRound(Room room, Haunt haunt, Map<String, List<Round>> rounds) =>
+    rounds[haunt.id].any((r) =>
+        r.complete &&
+        r.teamSubmitted &&
+        r.bids.length == room.numPlayers &&
+        (r.isAuction || r.pot >= haunt.price));
 
-final Selector<GameModel, bool> goingOnHaunt =
-    createSelector2(currentRound, getSelf, (currentRound, me) => currentRound.team.contains(me.id));
+bool hauntIsActive(Room room, Haunt haunt, Map<String, List<Round>> rounds) =>
+    hauntHasActiveRound(room, haunt, rounds) != null && !haunt.allDecided && !haunt.complete;
+
+final Selector<GameModel, bool> currentHauntIsActive = createSelector3(
+    getRoom,
+    currentHaunt,
+    getRounds,
+    (Room room, Haunt currentHaunt, Map<String, List<Round>> rounds) =>
+        hauntIsActive(room, currentHaunt, rounds));
+
+final Selector<GameModel, bool> goingOnHaunt = createSelector2(
+    currentRound, getSelf, (Round currentRound, Player me) => currentRound.team.contains(me.id));
 
 class Score {
   int scaryScore;
@@ -25,12 +32,12 @@ class Score {
   Score(this.scaryScore, this.friendlyScore);
 
   Team get winner => scaryScore >= 3 ? Team.SCARY : Team.FRIENDLY;
+
+  bool get gameOver => scaryScore >= 3 || friendlyScore >= 3;
 }
 
-final Selector<GameModel, bool> gameOver = createSelector1(getHaunts, (List<Haunt> haunts) {
-  Score score = calculateScore(haunts);
-  return score.scaryScore >= 3 || score.friendlyScore >= 3;
-});
+final Selector<GameModel, bool> gameOver =
+    createSelector1(getHaunts, (List<Haunt> haunts) => calculateScore(haunts).gameOver);
 
 Score calculateScore(List<Haunt> haunts) {
   int scaryScore = 0;

--- a/lib/selectors/haunt_selectors.dart
+++ b/lib/selectors/haunt_selectors.dart
@@ -5,22 +5,21 @@ import 'package:reselect/reselect.dart';
 
 import 'selectors.dart';
 
-bool hauntHasActiveRound(Room room, Haunt haunt, Map<String, List<Round>> rounds) =>
+bool hauntHasActiveRound(Room room, Map<String, List<Round>> rounds, Haunt haunt) =>
     rounds[haunt.id].any((r) =>
         r.complete &&
         r.teamSubmitted &&
         r.bids.length == room.numPlayers &&
         (r.isAuction || r.pot >= haunt.price));
 
-bool hauntIsActive(Room room, Haunt haunt, Map<String, List<Round>> rounds) =>
-    hauntHasActiveRound(room, haunt, rounds) != null && !haunt.allDecided && !haunt.complete;
-
 final Selector<GameModel, bool> currentHauntIsActive = createSelector3(
     getRoom,
-    currentHaunt,
     getRounds,
-    (Room room, Haunt currentHaunt, Map<String, List<Round>> rounds) =>
-        hauntIsActive(room, currentHaunt, rounds));
+    currentHaunt,
+    (Room room, Map<String, List<Round>> rounds, Haunt currentHaunt) =>
+        hauntHasActiveRound(room, rounds, currentHaunt) &&
+        !currentHaunt.allDecided &&
+        !currentHaunt.complete);
 
 final Selector<GameModel, bool> goingOnHaunt = createSelector2(
     currentRound, getSelf, (Round currentRound, Player me) => currentRound.team.contains(me.id));

--- a/lib/selectors/local_actions_selectors.dart
+++ b/lib/selectors/local_actions_selectors.dart
@@ -1,12 +1,31 @@
-import 'package:heist/selectors/selectors.dart';
+import 'package:heist/db/database_model.dart';
 import 'package:heist/state.dart';
 
-bool localHauntActionRecorded(GameModel gameModel, String hauntId, LocalHauntAction action) {
-  Set<LocalHauntAction> localActions = getLocalActions(gameModel).localHauntActions[hauntId];
-  return localActions != null && localActions.contains(action);
+bool localHauntActionRecorded(LocalActions localActions, String hauntId, LocalHauntAction action) {
+  Set<LocalHauntAction> localHauntActions = localActions.localHauntActions[hauntId];
+  return localHauntActions != null && localHauntActions.contains(action);
 }
 
-bool localRoundActionRecorded(GameModel gameModel, String roundId, LocalRoundAction action) {
-  Set<LocalRoundAction> localActions = getLocalActions(gameModel).localRoundActions[roundId];
-  return localActions != null && localActions.contains(action);
+bool localRoundActionRecorded(LocalActions localActions, String roundId, LocalRoundAction action) {
+  Set<LocalRoundAction> localRoundActions = localActions.localRoundActions[roundId];
+  return localRoundActions != null && localRoundActions.contains(action);
 }
+
+bool roundContinued(LocalActions localActions, Round round) => localRoundActionRecorded(
+      localActions,
+      round.id,
+      LocalRoundAction.RoundEndContinue,
+    );
+
+bool teamSelectionContinued(LocalActions localActions, Round currentRound) =>
+    localRoundActionRecorded(
+      localActions,
+      currentRound.id,
+      LocalRoundAction.TeamSelectionContinue,
+    );
+
+bool hauntContinued(LocalActions localActions, Haunt haunt) => localHauntActionRecorded(
+      localActions,
+      haunt.id,
+      LocalHauntAction.HauntEndContinue,
+    );

--- a/lib/selectors/selectors.dart
+++ b/lib/selectors/selectors.dart
@@ -31,6 +31,12 @@ bool requestInProcess(GameModel gameModel, Request request) =>
 Haunt currentHaunt(GameModel gameModel) =>
     getHaunts(gameModel).firstWhere((h) => !h.complete, orElse: null);
 
+Haunt previousHaunt(GameModel gameModel) =>
+    hauntByOrder(gameModel, currentHaunt(gameModel).order - 1);
+
+Haunt hauntByOrder(GameModel gameModel, int order) =>
+    getHaunts(gameModel).singleWhere((h) => h.order == order, orElse: null);
+
 Round lastRoundForHaunt(Room room, Map<String, List<Round>> rounds, Haunt haunt) {
   List<Round> roundsForHaunt = rounds[haunt.id];
   return hauntHasActiveRound(room, haunt, rounds)

--- a/lib/selectors/selectors.dart
+++ b/lib/selectors/selectors.dart
@@ -39,7 +39,7 @@ Haunt hauntByOrder(GameModel gameModel, int order) =>
 
 Round lastRoundForHaunt(Room room, Map<String, List<Round>> rounds, Haunt haunt) {
   List<Round> roundsForHaunt = rounds[haunt.id];
-  return hauntHasActiveRound(room, haunt, rounds)
+  return hauntHasActiveRound(room, rounds, haunt)
       ? roundsForHaunt.lastWhere((r) => r.complete)
       : roundsForHaunt.firstWhere((r) => !r.complete);
 }

--- a/lib/selectors/selectors.dart
+++ b/lib/selectors/selectors.dart
@@ -53,4 +53,4 @@ final Selector<GameModel, Round> previousRound = createSelector3(
         roundByOrder(rounds, currentHaunt, currentRound.order - 1));
 
 Round roundByOrder(Map<String, List<Round>> rounds, Haunt haunt, int order) =>
-    rounds[haunt.id].singleWhere((r) => r.order == order);
+    rounds[haunt.id].singleWhere((r) => r.order == order, orElse: null);

--- a/lib/selectors/team_picker_selectors.dart
+++ b/lib/selectors/team_picker_selectors.dart
@@ -39,17 +39,11 @@ Player leaderForRound(GameModel gameModel, Round round) {
   return players.singleWhere((Player p) => p.order == leaderOrder);
 }
 
-final Selector<GameModel, Set<Player>> currentTeam = createSelector2(
-    getPlayers,
-    currentRound,
-    (List<Player> players, Round currentRound) => players.where((Player p) {
-          // Reselect needed this bool explicitly typed
-          bool playerInTeam = currentRound.team.contains(p.id);
-          return playerInTeam;
-        }).toSet());
+final Selector<GameModel, Set<Player>> currentTeam = createSelector2(getPlayers, currentRound,
+    (List<Player> players, Round currentRound) => teamForRound(players, currentRound));
 
 final Selector<GameModel, bool> currentTeamIsFull = createSelector2(currentHaunt, currentTeam,
     (Haunt currentHaunt, Set<Player> currentTeam) => currentHaunt.numPlayers == currentTeam.length);
 
-Set<Player> teamForRound(GameModel gameModel, Round round) =>
-    getPlayers(gameModel).where((p) => round.team.contains(p.id)).toSet();
+Set<Player> teamForRound(List<Player> players, Round round) =>
+    players.where((p) => round.team.contains(p.id)).toSet();

--- a/lib/widget/decision.dart
+++ b/lib/widget/decision.dart
@@ -11,97 +11,97 @@ import 'package:redux/redux.dart';
 
 import 'common.dart';
 
-Widget activeHaunt(BuildContext context, Store<GameModel> store) {
-  List<Widget> children = [
-    roundTitleCard(context, store),
-    observeHaunt(store),
-  ];
-  if (goingOnHaunt(store.state)) {
-    children.add(
-      makeDecision(context, store),
-    );
-  }
-  return new Column(children: children);
+class ActiveHaunt extends StatefulWidget {
+  final Store<GameModel> _store;
+
+  ActiveHaunt(this._store);
+
+  @override
+  State<StatefulWidget> createState() => _ActiveHauntState();
 }
 
-Widget observeHaunt(Store<GameModel> store) {
-  return new StoreConnector<GameModel, Map<String, String>>(
-      converter: (store) => currentHaunt(store.state).decisions,
+class _ActiveHauntState extends State<ActiveHaunt> {
+  Widget observeHaunt() => StoreConnector<GameModel, Map<String, String>>(
       distinct: true,
+      converter: (store) => currentHaunt(store.state).decisions,
       builder: (context, decisions) {
-        return new Card(
+        return Card(
             elevation: 2.0,
-            child: new Container(
+            child: Padding(
                 padding: paddingMedium,
-                child: new Column(children: [
-                  new Text(AppLocalizations.of(context).hauntInProgress, style: infoTextStyle),
-                  new TeamGridView(
-                    observeHauntChildren(
-                      context,
-                      currentTeam(store.state),
-                      decisions,
-                    ),
+                child: Column(children: [
+                  Text(AppLocalizations.of(context).hauntInProgress, style: infoTextStyle),
+                  TeamGridView(
+                    observeHauntChildren(currentTeam(widget._store.state), decisions),
                   ),
                 ])));
       });
+
+  List<Widget> observeHauntChildren(Set<Player> team, Map<String, String> decisions) {
+    Color color = Theme.of(context).primaryColor;
+    return List.generate(team.length, (i) {
+      Player player = team.elementAt(i);
+      bool decisionMade = decisions[player.id] != null;
+      return Container(
+          alignment: Alignment.center,
+          decoration:
+              BoxDecoration(border: Border.all(color: color), color: decisionMade ? color : null),
+          child: Text(
+            player.name,
+            style: TextStyle(fontSize: 16.0, color: decisionMade ? Colors.white : null),
+          ));
+    });
+  }
+
+  Widget makeDecision() => StoreConnector<GameModel, Map<String, String>>(
+      distinct: true,
+      converter: (store) => currentHaunt(store.state).decisions,
+      builder: (context, decisions) {
+        Player me = getSelf(widget._store.state);
+        List<Widget> children = [];
+        if (decisions.containsKey(me.id)) {
+          children.add(
+            Text(AppLocalizations.of(context).youHaveMadeYourChoice, style: infoTextStyle),
+          );
+        } else {
+          children.addAll([
+            Padding(
+              padding: paddingSmall,
+              child: Text(AppLocalizations.of(context).makeYourChoice, style: titleTextStyle),
+            ),
+            decisionButton(Scare, true),
+            decisionButton(Steal, me.role != Roles.brenda.roleId),
+            decisionButton(Tickle, Roles.getTeam(me.role) == Team.FRIENDLY),
+          ]);
+        }
+        return Card(
+            elevation: 2.0,
+            child: Container(
+                padding: paddingMedium,
+                alignment: Alignment.center,
+                child:
+                    Column(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: children)));
+      });
+
+  Widget decisionButton(String decision, bool enabled) => Container(
+      padding: paddingSmall,
+      child: RaisedButton(
+        onPressed: enabled ? () => widget._store.dispatch(MakeDecisionAction(decision)) : null,
+        child: Text(decision, style: buttonTextStyle),
+      ));
+
+  @override
+  Widget build(BuildContext context) {
+    List<Widget> children = [
+      roundTitleCard(context, widget._store),
+      observeHaunt(),
+    ];
+    if (goingOnHaunt(widget._store.state)) {
+      children.add(makeDecision());
+    }
+    return Padding(
+      padding: paddingMedium,
+      child: Column(children: children),
+    );
+  }
 }
-
-List<Widget> observeHauntChildren(
-    BuildContext context, Set<Player> team, Map<String, String> decisions) {
-  Color color = Theme.of(context).accentColor;
-  return new List.generate(team.length, (i) {
-    Player player = team.elementAt(i);
-    bool decisionMade = decisions[player.id] != null;
-    return new Container(
-        alignment: Alignment.center,
-        decoration: new BoxDecoration(
-            border: new Border.all(color: color), color: decisionMade ? color : null),
-        child: new Text(
-          player.name,
-          style: new TextStyle(fontSize: 16.0, color: decisionMade ? Colors.white : null),
-        ));
-  });
-}
-
-Widget makeDecision(BuildContext context, Store<GameModel> store) =>
-    new StoreConnector<GameModel, Map<String, String>>(
-        converter: (store) => currentHaunt(store.state).decisions,
-        distinct: true,
-        builder: (context, decisions) {
-          Player me = getSelf(store.state);
-          List<Widget> children = [];
-          if (decisions.containsKey(me.id)) {
-            children.add(
-              new Text(AppLocalizations.of(context).youHaveMadeYourChoice, style: infoTextStyle),
-            );
-          } else {
-            children.addAll([
-              new Padding(
-                padding: paddingSmall,
-                child: new Text(AppLocalizations.of(context).makeYourChoice, style: titleTextStyle),
-              ),
-              new Column(
-                children: [],
-              ),
-              decisionButton(context, store, Scare, true),
-              decisionButton(context, store, Steal, me.role != Roles.brenda.roleId),
-              decisionButton(context, store, Tickle, Roles.getTeam(me.role) == Team.FRIENDLY),
-            ]);
-          }
-          return new Card(
-              elevation: 2.0,
-              child: new Container(
-                  padding: paddingMedium,
-                  alignment: Alignment.center,
-                  child: new Column(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: children)));
-        });
-
-Widget decisionButton(
-        BuildContext context, Store<GameModel> store, String decision, bool enabled) =>
-    new Container(
-        padding: paddingSmall,
-        child: new RaisedButton(
-          onPressed: enabled ? () => store.dispatch(new MakeDecisionAction(decision)) : null,
-          child: new Text(decision, style: buttonTextStyle),
-        ));

--- a/lib/widget/endgame.dart
+++ b/lib/widget/endgame.dart
@@ -9,153 +9,169 @@ import 'package:redux/redux.dart';
 
 import 'common.dart';
 
-List<Widget> playerDecisions(BuildContext context, Store<GameModel> store, Haunt haunt) {
-  List<Widget> heistDecisions = [];
-  haunt.decisions.forEach((playerId, decision) {
-    Player player = getPlayerById(store.state, playerId);
-    heistDecisions.add(
-      new Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          new Text('${player.name}:', style: infoTextStyle),
-          new Text(
-            ' $decision',
-            style: new TextStyle(
-              fontSize: 16.0,
-              color: decisionColour(decision),
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-        ],
-      ),
-    );
-  });
-  return heistDecisions;
+class Endgame extends StatefulWidget {
+  final Store<GameModel> _store;
+
+  Endgame(this._store);
+
+  @override
+  State<StatefulWidget> createState() => _EndgameState();
 }
 
-Text heistResultText(BuildContext context, bool wasSuccess) {
-  return wasSuccess
-      ? new Text(
-          AppLocalizations.of(context).success.toUpperCase(),
-          style: const TextStyle(
-              fontSize: 16.0, fontWeight: FontWeight.bold, color: HeistColors.green),
-        )
-      : new Text(
-          AppLocalizations.of(context).fail.toUpperCase(),
-          style: const TextStyle(fontSize: 16.0, fontWeight: FontWeight.bold, color: Colors.red),
-        );
-}
-
-Widget hauntSummary(BuildContext context, Store<GameModel> store, Haunt haunt, int pot) => new Card(
-    elevation: 2.0,
-    child: new Container(
-      padding: paddingMedium,
-      child: new Column(
-        children: [
-          new Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-            new Text(AppLocalizations.of(context).hauntTitle(haunt.order), style: boldTextStyle),
-            heistResultText(context, haunt.wasSuccess),
-          ]),
-          new Divider(),
-          new Container(
-            padding: paddingSmall,
-            child: new Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-              new Text(AppLocalizations.of(context).hauntPrice(haunt.price), style: infoTextStyle),
-              new Text(AppLocalizations.of(context).hauntPot(pot), style: infoTextStyle),
-            ]),
-          ),
-          new Column(
-            children: playerDecisions(context, store, haunt),
-          ),
-        ],
-      ),
-    ));
-
-Widget winner(BuildContext context, Score score) => new Card(
-      elevation: 2.0,
-      child: new Container(
-        alignment: Alignment.center,
-        padding: paddingMedium,
-        child: new Column(
+class _EndgameState extends State<Endgame> {
+  List<Widget> playerDecisions(Haunt haunt) {
+    List<Widget> heistDecisions = [];
+    haunt.decisions.forEach((playerId, decision) {
+      Player player = getPlayerById(widget._store.state, playerId);
+      heistDecisions.add(
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            new Container(
-                padding: paddingTitle,
-                child: new Text(AppLocalizations.of(context).winner(score.winner.toString()),
-                    style: titleTextStyle)),
-            new Row(mainAxisAlignment: MainAxisAlignment.spaceAround, children: [
-              new Text(Team.SCARY.toString(), style: infoTextStyle),
-              new Text(
-                  AppLocalizations.of(context).teamScores(score.scaryScore, score.friendlyScore),
-                  style: new TextStyle(fontSize: 32.0)),
-              new Text(Team.FRIENDLY.toString(), style: infoTextStyle),
-            ])
-          ],
-        ),
-      ),
-    );
-
-Widget fullPlayerListForTeam(BuildContext context, List<Player> players, Team team, Color color) {
-  List<Player> playersInTeam = players.where((p) => Roles.getTeam(p.role) == team).toList();
-  return new Column(
-    children: new List.generate(playersInTeam.length + 1, (i) {
-      Player player = playersInTeam[0];
-      return new Padding(
-        padding: paddingBelowText,
-        child: new Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            new Text(
-              player.name,
-              style: infoTextStyle,
-            ),
-            new Text(
-              Roles.getRoleDisplayName(context, player.role),
-              style: new TextStyle(color: color),
+            Text('${player.name}:', style: infoTextStyle),
+            Text(
+              ' $decision',
+              style: TextStyle(
+                fontSize: 16.0,
+                color: decisionColour(decision),
+                fontWeight: FontWeight.bold,
+              ),
             ),
           ],
         ),
       );
-    }),
-  );
-}
-
-Widget fullPlayerList(BuildContext context, Store<GameModel> store) {
-  List<Player> players = getPlayers(store.state);
-  return new Card(
-    elevation: 2.0,
-    child: new Padding(
-      padding: paddingMedium,
-      child: new Column(children: [
-        new Padding(
-          padding: paddingTitle,
-          child: new Text(AppLocalizations.of(context).players, style: titleTextStyle),
-        ),
-        new Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            fullPlayerListForTeam(context, players, Team.SCARY, Colors.pink),
-            fullPlayerListForTeam(context, players, Team.FRIENDLY, Colors.purple),
-          ],
-        )
-      ]),
-    ),
-  );
-}
-
-Widget endgame(BuildContext context, Store<GameModel> store) {
-  List<Haunt> haunts = getHaunts(store.state);
-  Score score = calculateScore(haunts);
-
-  List<Widget> children = [
-    winner(context, score),
-    fullPlayerList(context, store),
-  ];
-
-  Map<String, List<Round>> rounds = getRounds(store.state);
-  for (Haunt haunt in haunts) {
-    Round lastRound = rounds[haunt.id].last;
-    children.add(hauntSummary(context, store, haunt, lastRound.pot));
+    });
+    return heistDecisions;
   }
 
-  return new ListView(children: children);
+  Text heistResultText(bool wasSuccess) => wasSuccess
+      ? Text(
+          AppLocalizations.of(context).success.toUpperCase(),
+          style: const TextStyle(
+              fontSize: 16.0, fontWeight: FontWeight.bold, color: HeistColors.green),
+        )
+      : Text(
+          AppLocalizations.of(context).fail.toUpperCase(),
+          style: const TextStyle(
+              fontSize: 16.0, fontWeight: FontWeight.bold, color: HeistColors.peach),
+        );
+
+  Widget hauntSummary(Haunt haunt, int pot) => Card(
+      elevation: 2.0,
+      child: Padding(
+        padding: paddingMedium,
+        child: Column(
+          children: [
+            Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+              Text(AppLocalizations.of(context).hauntTitle(haunt.order), style: boldTextStyle),
+              iconText(
+                Icon(Icons.bubble_chart),
+                Text(pot.toString(), style: infoTextStyle),
+              ),
+              heistResultText(haunt.wasSuccess),
+            ]),
+            Divider(),
+            Column(children: playerDecisions(haunt)),
+          ],
+        ),
+      ));
+
+  Widget winner(Score score) => Card(
+        elevation: 2.0,
+        child: Container(
+          alignment: Alignment.center,
+          padding: paddingMedium,
+          child: Column(
+            children: [
+              Padding(
+                padding: paddingTitle,
+                child: Text(
+                  AppLocalizations.of(context).winner(score.winner.toString()),
+                  style: titleTextStyle,
+                ),
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  Text(Team.SCARY.toString(), style: infoTextStyle),
+                  Text(
+                    AppLocalizations.of(context).teamScores(score.scaryScore, score.friendlyScore),
+                    style: TextStyle(fontSize: 32.0),
+                  ),
+                  Text(Team.FRIENDLY.toString(), style: infoTextStyle),
+                ],
+              )
+            ],
+          ),
+        ),
+      );
+
+  Widget fullPlayerListForTeam(List<Player> players, Team team, Color color) {
+    List<Player> playersInTeam = players.where((p) => Roles.getTeam(p.role) == team).toList();
+    return Column(
+      children: List.generate(playersInTeam.length, (i) {
+        Player player = playersInTeam[i];
+        return Padding(
+          padding: paddingBelowText,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                player.name,
+                style: infoTextStyle,
+              ),
+              Text(
+                Roles.getRoleDisplayName(context, player.role),
+                style: TextStyle(color: color),
+              ),
+            ],
+          ),
+        );
+      }),
+    );
+  }
+
+  Widget fullPlayerList() {
+    List<Player> players = getPlayers(widget._store.state);
+    return Card(
+      elevation: 2.0,
+      child: Padding(
+        padding: paddingMedium,
+        child: Column(children: [
+          Padding(
+            padding: paddingTitle,
+            child: Text(AppLocalizations.of(context).players, style: titleTextStyle),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              fullPlayerListForTeam(players, Team.SCARY, Colors.pink),
+              fullPlayerListForTeam(players, Team.FRIENDLY, Colors.purple),
+            ],
+          )
+        ]),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    List<Haunt> haunts = getHaunts(widget._store.state);
+    Score score = calculateScore(haunts);
+
+    List<Widget> children = [
+      winner(score),
+      fullPlayerList(),
+    ];
+
+    Map<String, List<Round>> rounds = getRounds(widget._store.state);
+    for (Haunt haunt in haunts) {
+      Round lastRound = lastRoundForHaunt(getRoom(widget._store.state), rounds, haunt);
+      children.add(hauntSummary(haunt, lastRound.pot));
+    }
+
+    return Padding(
+      padding: paddingMedium,
+      child: ListView(children: children),
+    );
+  }
 }

--- a/lib/widget/game.dart
+++ b/lib/widget/game.dart
@@ -87,7 +87,7 @@ class GameState extends State<Game> {
     if (!getRoom(_store.state).complete && !completingGame) {
       _store.dispatch(CompleteGameAction());
     }
-    return endgame(context, _store);
+    return Endgame(_store);
   }
 
   Widget _resolveAuctionWinners(bool resolvingAuction) {
@@ -115,7 +115,7 @@ class GameState extends State<Game> {
     // Show bidding summary of previous round (if it exists and as long as a team
     // has not yet been selected for the current round)
     if (viewModel.waitingForTeam && !viewModel.previousRoundContinued) {
-      return appendFooter(RoundEnd(_store, viewModel.currentRoundOrder - 1));
+      return RoundEnd(_store, viewModel.currentRoundOrder - 1);
     }
 
     // Team selection (not needed for auctions)
@@ -137,7 +137,7 @@ class GameState extends State<Game> {
 
     // Bidding summary
     if (!viewModel.roundComplete || !viewModel.currentRoundContinued) {
-      return appendFooter(RoundEnd(_store, viewModel.currentRoundOrder));
+      return RoundEnd(_store, viewModel.currentRoundOrder);
     }
 
     // Haunt is currently happening
@@ -153,14 +153,12 @@ class GameState extends State<Game> {
     return null;
   }
 
-  Widget appendFooter(Widget child, {bool indicatorOnRight = true}) {
-    return Column(
-      children: [
-        Expanded(child: child),
-        footer(indicatorOnRight),
-      ],
-    );
-  }
+  Widget appendFooter(Widget child, {bool indicatorOnRight = true}) => Column(
+        children: [
+          Expanded(child: child),
+          footer(indicatorOnRight),
+        ],
+      );
 
   Widget footer(bool indicatorOnRight) {
     List<Widget> children = indicatorOnRight

--- a/lib/widget/game_history.dart
+++ b/lib/widget/game_history.dart
@@ -70,7 +70,11 @@ class _GameHistoryState extends State<GameHistory> {
   }
 
   Widget hauntPopup(int currentHauntOrder, Haunt haunt) {
-    Round lastRound = lastRoundForHaunt(widget._store.state, haunt);
+    Round lastRound = lastRoundForHaunt(
+      getRoom(widget._store.state),
+      getRounds(widget._store.state),
+      haunt,
+    );
 
     List<Widget> title = [
       Text(

--- a/lib/widget/game_history.dart
+++ b/lib/widget/game_history.dart
@@ -116,7 +116,7 @@ class _GameHistoryState extends State<GameHistory> {
     ];
 
     if (haunt.complete) {
-      Set<Player> team = teamForRound(widget._store.state, lastRound);
+      Set<Player> team = teamForRound(getPlayers(widget._store.state), lastRound);
       Player leader = leaderForRound(widget._store.state, lastRound);
       hauntPopupChildren.addAll([
         Divider(),

--- a/lib/widget/haunt_end.dart
+++ b/lib/widget/haunt_end.dart
@@ -89,7 +89,7 @@ class _HauntEndState extends State<HauntEnd> {
         ],
       );
 
-  Widget _hauntResult(BuildContext context) {
+  Widget _hauntResult() {
     Haunt haunt = hauntByOrder(_store.state, widget._hauntOrder);
     List<String> decisions = List.of(haunt.decisions.values.toList());
     if (decisions.isEmpty) {
@@ -171,6 +171,6 @@ class _HauntEndState extends State<HauntEnd> {
     if (!gameIsReady(_store.state)) {
       return Container();
     }
-    return SingleChildScrollView(child: _hauntResult(context));
+    return SingleChildScrollView(child: _hauntResult());
   }
 }

--- a/lib/widget/haunt_end.dart
+++ b/lib/widget/haunt_end.dart
@@ -21,9 +21,7 @@ class HauntEnd extends StatefulWidget {
   HauntEnd(this._store);
 
   @override
-  State<StatefulWidget> createState() {
-    return new _HauntEndState(_store);
-  }
+  State<StatefulWidget> createState() => _HauntEndState(_store);
 }
 
 class _HauntEndState extends State<HauntEnd> {
@@ -31,15 +29,15 @@ class _HauntEndState extends State<HauntEnd> {
 
   _HauntEndState(this._store);
 
-  List<Widget> _hauntDecisions(List<String> decisions) => new List.generate(
+  List<Widget> _hauntDecisions(List<String> decisions) => List.generate(
         decisions.length,
         (i) {
           String decision = decisions[i];
-          return new Container(
+          return Container(
             alignment: Alignment.center,
             padding: paddingTiny,
-            child: new Text(decision,
-                style: new TextStyle(
+            child: Text(decision,
+                style: TextStyle(
                   fontSize: 16.0,
                   color: decisionColour(decision),
                   fontWeight: FontWeight.bold,
@@ -48,57 +46,55 @@ class _HauntEndState extends State<HauntEnd> {
         },
       );
 
-  Widget _hauntContinueButton() {
-    return new StoreConnector<GameModel, bool>(
-        converter: (store) => requestInProcess(store.state, Request.CompletingHaunt),
-        distinct: true,
-        builder: (context, completingHeist) => new Padding(
-              padding: paddingSmall,
-              child: new RaisedButton(
-                child: new Text(
-                  AppLocalizations.of(context).continueButton,
-                  style: buttonTextStyle,
-                ),
-                onPressed:
-                    completingHeist ? null : () => _store.dispatch(new CompleteHauntAction()),
+  Widget _hauntContinueButton() => StoreConnector<GameModel, bool>(
+      distinct: true,
+      converter: (store) => requestInProcess(store.state, Request.CompletingHaunt),
+      builder: (context, completingHeist) => Padding(
+            padding: paddingSmall,
+            child: RaisedButton(
+              child: Text(
+                AppLocalizations.of(context).continueButton,
+                style: buttonTextStyle,
               ),
-            ));
-  }
+              onPressed: completingHeist ? null : () => _store.dispatch(CompleteHauntAction()),
+            ),
+          ));
 
   Widget _hauntIcon(bool wasSuccess) {
+    const double size = 40.0;
     return wasSuccess
-        ? const Icon(Icons.verified_user, color: HeistColors.green, size: 40.0)
-        : const Icon(Icons.cancel, color: Colors.red, size: 40.0);
+        ? const Icon(Icons.verified_user, color: HeistColors.green, size: size)
+        : const Icon(Icons.cancel, color: HeistColors.peach, size: size);
   }
 
-  Widget _hauntDetails(Haunt haunt, int pot) => new Row(
+  Widget _hauntDetails(Haunt haunt, int pot) => Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
-          new Text(AppLocalizations.of(context).hauntTitle(haunt.order), style: boldTextStyle),
-          new VerticalDivider(),
+          Text(AppLocalizations.of(context).hauntTitle(haunt.order), style: boldTextStyle),
+          VerticalDivider(),
           iconText(
-            new Icon(Icons.monetization_on, color: Colors.teal),
-            new Text(pot.toString(), style: bigNumberTextStyle),
+            Icon(Icons.bubble_chart),
+            Text(pot.toString(), style: bigNumberTextStyle),
           ),
-          new VerticalDivider(),
+          VerticalDivider(),
           _hauntIcon(haunt.wasSuccess),
         ],
       );
 
   Widget _hauntResult(BuildContext context) {
     Haunt haunt = currentHaunt(_store.state);
-    List<String> decisions = new List.of(haunt.decisions.values.toList());
+    List<String> decisions = List.of(haunt.decisions.values.toList());
     if (decisions.isEmpty) {
       return null;
     }
     int pot = currentRound(_store.state).pot;
-    decisions.shuffle(new Random(haunt.id.hashCode));
+    decisions.shuffle(Random(haunt.id.hashCode));
 
     List<Widget> children = [
       _hauntDetails(haunt, pot),
-      new Divider(),
+      Divider(),
       hauntTeam(context, currentTeam(_store.state), currentLeader(_store.state)),
-      new Divider(),
+      Divider(),
     ];
 
     children.addAll(_hauntDecisions(decisions));
@@ -111,16 +107,16 @@ class _HauntEndState extends State<HauntEnd> {
       color: Colors.teal,
     );
     children.addAll([
-      new Divider(),
-      new Padding(
+      Divider(),
+      Padding(
         padding: paddingSmall,
-        child: new Column(
+        child: Column(
           children: [
-            new Text(
+            Text(
               '+$brendaPayout',
               style: potResolutionTextStyle,
             ),
-            new Text(
+            Text(
               AppLocalizations.of(context)
                   .brendaReceived(Roles.getRoleDisplayName(context, Roles.brenda.roleId)),
               style: infoTextStyle,
@@ -128,15 +124,15 @@ class _HauntEndState extends State<HauntEnd> {
           ],
         ),
       ),
-      new Padding(
+      Padding(
         padding: paddingSmall,
-        child: new Column(
+        child: Column(
           children: [
-            new Text(
+            Text(
               '+$bertiePayout',
               style: potResolutionTextStyle,
             ),
-            new Text(
+            Text(
               AppLocalizations.of(context)
                   .sharedBetween(Roles.getRoleDisplayName(context, Roles.bertie.roleId), Steal),
               style: infoTextStyle,
@@ -150,11 +146,12 @@ class _HauntEndState extends State<HauntEnd> {
       children.add(_hauntContinueButton());
     }
 
-    return new Card(
+    return Card(
       elevation: 2.0,
-      child: new Container(
+      margin: paddingMedium,
+      child: Padding(
         padding: paddingMedium,
-        child: new Column(children: children),
+        child: Column(children: children),
       ),
     );
   }
@@ -162,8 +159,8 @@ class _HauntEndState extends State<HauntEnd> {
   @override
   Widget build(BuildContext context) {
     if (!gameIsReady(_store.state)) {
-      return new Container();
+      return Container();
     }
-    return new SingleChildScrollView(child: _hauntResult(context));
+    return SingleChildScrollView(child: _hauntResult(context));
   }
 }

--- a/lib/widget/round_end.dart
+++ b/lib/widget/round_end.dart
@@ -27,7 +27,7 @@ class RoundEnd extends StatefulWidget {
 
 class _RoundEndState extends State<RoundEnd> with SingleTickerProviderStateMixin {
   /// Height of the bar indicating the price
-  static const double _thresholdHeight = 225.0;
+  static const double _thresholdHeight = 275.0;
 
   static const double _barWidth = 75.0;
   static const double _labelContainerWidth = 75.0;
@@ -338,7 +338,7 @@ class _RoundEndState extends State<RoundEnd> with SingleTickerProviderStateMixin
   /// line when it grows.
   double _getPotBarHeight(int pot, int price, bool hauntIsActive) {
     if (hauntIsActive) {
-      double boost = min((pot - price) * 12.0, 60.0);
+      double boost = min((pot - price) * 20.0, 100.0);
       return _thresholdHeight + boost;
     }
     return (pot / price) * _thresholdHeight;

--- a/lib/widget/round_end.dart
+++ b/lib/widget/round_end.dart
@@ -350,9 +350,9 @@ class _RoundEndState extends State<RoundEnd> with SingleTickerProviderStateMixin
   Widget _barStack() {
     Player me = getSelf(_store.state);
     Haunt haunt = currentHaunt(_store.state);
-    Round round = roundByOrder(haunt, getRounds(_store.state), _roundOrder);
+    Round round = roundByOrder(getRounds(_store.state), haunt, _roundOrder);
     int price = haunt.price;
-    bool hauntActive = hauntIsActive(_store.state);
+    bool hauntActive = currentHauntIsActive(_store.state);
     bool goingOnHaunt = round.team.contains(me.id);
     int pot = round.pot;
     int bid = round.bids[me.id].amount;


### PR DESCRIPTION
I realised there were some problems remaining due to the new way of creating haunts and rounds up front.

The main change here is: https://github.com/acjc/heist/compare/current-round-fixes?expand=1#diff-b86934f137c4162898e24d52e82feea2R8

`hauntHasActiveRound()` which I use to figure out which is the current round. If a haunt is going ahead, the 'current round' is actually the last completed one, rather than the first uncompleted one.

Also added local continues for end of haunts.