### PR TITLE
Small fixes in the end game screen

### DIFF
--- a/lib/widget/endgame.dart
+++ b/lib/widget/endgame.dart
@@ -165,8 +165,11 @@ class _EndgameState extends State<Endgame> {
 
     Map<String, List<Round>> rounds = getRounds(widget._store.state);
     for (Haunt haunt in haunts) {
-      Round lastRound = lastRoundForHaunt(getRoom(widget._store.state), rounds, haunt);
-      children.add(hauntSummary(haunt, lastRound.pot));
+      if (haunt.allDecided) {
+        Round lastRound = lastRoundForHaunt(
+            getRoom(widget._store.state), rounds, haunt);
+        children.add(hauntSummary(haunt, lastRound.pot));
+      }
     }
 
     return Padding(

--- a/lib/widget/endgame.dart
+++ b/lib/widget/endgame.dart
@@ -113,7 +113,7 @@ class _EndgameState extends State<Endgame> {
         return Padding(
           padding: paddingBelowText,
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               Text(
                 player.name,


### PR DESCRIPTION
A couple of very small fixes in their separate commits.

I think I've done the issue about showing who the leader was in the end screen too, but I've run into other problems along the way. I think it'll be better to mark the last round and haunt as completed correctly before.